### PR TITLE
Support yearly periodicals.

### DIFF
--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -720,6 +720,9 @@ class AlmaClient {
           $year = $year_holdings->getAttribute('value');
           foreach ($year_holdings->childNodes as $issue_holdings) {
             $issue = $issue_holdings->getAttribute('value');
+            if (empty($issue)) {
+              $issue = '1';
+            }
             $holdings = AlmaClient::process_catalogue_record_holdings($issue_holdings);
             $record['holdings'][$year][$issue] = $holdings;
             $issue_list = array(


### PR DESCRIPTION
Alma reponds differently when a periodical only has one issue each year.
Basically because the name of that issue is the year instead of a number during that year.
I chose the easy way out and simply called the issue '1'.

The best way would of course be to change ding_periodical to support yearly periodicals.
