### PR TITLE
Issue 1119: Support pickup numbers which are not integers.

### DIFF
--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -347,7 +347,7 @@ class AlmaClient {
       }
 
       if ($reservation['status'] == 'fetchable') {
-        $reservation['pickup_number'] = (integer) $item->getAttribute('pickUpNo');
+        $reservation['pickup_number'] = $item->getAttribute('pickUpNo');
         $reservation['pickup_expire_date'] = $item->getAttribute('pickUpExpireDate');
       }
 


### PR DESCRIPTION
Some Alma installations e.g. the Copenhagen libraries return strings e.g. “Nr. 56”.

Issue: http://platform.dandigbib.org/issues/1119